### PR TITLE
Adding the ability to create a branch deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
         - run: npm i serverless@1.30.3
         - run:
             name: Deploy to test
-            command: ".circleci/deploy.sh test $(date -d 'tomorrow' -I)"
+            command: ".circleci/deploy.sh ${CIRCLE_BRANCH} $(date -d 'tomorrow' -I)"
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,30 @@ jobs:
             name: Deploy to prod
             command: .circleci/deploy.sh production
 
+  deploy_branch:
+      docker:
+        - image: circleci/node:8.10
+      working_directory: ~/repo
+      steps:
+        - checkout
+        - restore_cache:
+            keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+        - run: npm i
+        - save_cache:
+            paths:
+              - node_modules
+            key: v1-dependencies-{{ checksum "package.json" }}
+        - run: npm test -- --forbid-only
+        - run: npm run build
+        - run: npm i serverless@1.30.3
+        - run:
+            name: Deploy to test
+            command: .circleci/deploy.sh test
+
+
+
 workflows:
   version: 2
   build_and_test:
@@ -70,6 +94,13 @@ workflows:
       - package:
          requires:
             - build
+         filters:
+           branches:
+             ignore: master
+      - deploy_branch:
+         requires:
+            - build
+         context: "aws.amazon.com/alexjpaz/circleci"
          filters:
            branches:
              ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
         - run: npm i serverless@1.30.3
         - run:
             name: Deploy to test
-            command: .circleci/deploy.sh test
+            command: ".circleci/deploy.sh test $(date -d 'tomorrow' -I)"
 
 
 

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 STAGE=$1
+export expiresAt=$2
 
 sls() {
     node_modules/.bin/serverless $@

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 STAGE=$1
+STAGE=${STAGE//\//_}
+
+echo "STAGE=${STAGE}"
+
 export expiresAt=$2
 
 sls() {

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 STAGE=$1
-STAGE=${STAGE//\//_}
+STAGE=${STAGE//\//-}
 
 echo "STAGE=${STAGE}"
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,9 @@ provider:
   stage: dev
   region: us-east-1
 
+  stackTags:
+    expiresAt: "${env:expiresAt}"
+
   # @see https://github.com/dougmoscrop/serverless-http/issues/88
   # @see https://github.com/serverless/serverless/pull/6063
   apiGateway:


### PR DESCRIPTION
This pull request adds the ability to create a temporary stack from a branch build. It adds an `expiresAt` tag the [AWS account reaper](https://gitlab.com/alexjpaz/aws-reaper) looks for to clean up after a given time (currently set to the next day of the build).