### PR TITLE
Add redirect for /vgcc to VGCC Hub

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -114,3 +114,8 @@
   from = "/twitch/ra"
   to = "https://retroachievements.org/user/alexjpaz"
   status = 302
+
+[[redirects]]
+  from = "/vgcc"
+  to = "https://vgcc-hub.github.io/"
+  status = 302


### PR DESCRIPTION
## Overview

Creating a redirect for https://github.com/vgcc-hub/vgcc-hub.github.io